### PR TITLE
Add image placeholders with Iowa flair

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import HowItWorks from './components/HowItWorks';
 import OnboardingWidget from './components/OnboardingWidget';
 import PricingPlans from './components/PricingPlans';
 import WhyChooseUs from './components/WhyChooseUs';
-import Testimonials from './components/Testimonials';
+import Testimonials from "./components/Testimonials";
+import ImageGallery from "./components/ImageGallery";
 import FAQ from './components/FAQ';
 import Footer from './components/Footer';
 
@@ -102,6 +103,7 @@ function App() {
         <PricingPlans calculatedPrice={calculatedPrice} selectedDogs={selectedDogs} />
         <WhyChooseUs />
         <Testimonials />
+          <ImageGallery />
         <FAQ />
         
         {/* CTA Strip */}
@@ -120,6 +122,7 @@ function App() {
             <p className="text-xl text-white/90 mb-8">
               Join thousands of happy dogs and their owners!
             </p>
+              <img src="/images/iowa-landscape.jpg" alt="Peaceful Iowa landscape reminding me of home" className="mx-auto rounded-lg shadow-md w-full max-w-md mb-6" />
             <button 
               onClick={() => scrollToSection('onboarding')}
               className="bg-white text-green-600 px-8 py-4 rounded-full font-semibold text-lg hover:bg-gray-100 transition-colors transform hover:scale-105"

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -36,6 +36,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onGetStarted }) => {
             <p className="text-xl md:text-2xl text-white/90 mb-8 max-w-2xl">
               We chase the mess so you can chase the ball! Professional weekly dog waste removal with eco-friendly fertilizer treatment.
             </p>
+            <img src="/images/me-with-dogs.jpg" alt="Me playing with dogs on the lawn" className="mx-auto rounded-lg shadow-md w-full max-w-md mb-6" />
             
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
               <button 

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -75,6 +75,9 @@ const HowItWorks: React.FC = () => {
         </div>
         
         <div className="text-center mt-12">
+          <img src="/images/happy-dog-lawn.jpg" alt="Happy dog running on a lush green Iowa lawn" className="mx-auto rounded-lg shadow-md w-full max-w-md mb-6" />
+        </div>
+        <div className="text-center mt-12">
           <div className="inline-flex items-center space-x-2 bg-green-100 px-6 py-3 rounded-full">
             <span className="text-green-600 font-semibold">✨ It's that simple!</span>
             <span className="text-2xl animate-bounce">🐕</span>

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const ImageGallery: React.FC = () => {
+  const images = [
+    { src: '/images/me-playing-with-dogs.jpg', alt: 'Me playing fetch with a pack of dogs on a sunny Iowa day' },
+    { src: '/images/happy-dogs.jpg', alt: 'Happy dogs smiling for the camera' },
+    { src: '/images/green-lawn.jpg', alt: 'Lush green lawn after our eco-friendly treatment' },
+    { src: '/images/iowa-landscape.jpg', alt: 'Rolling Iowa fields at golden hour' },
+    { src: '/images/iowa-state-memories.jpg', alt: 'Throwback photo from Iowa State University campus' }
+  ];
+
+  return (
+    <section id="gallery" className="py-20 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl md:text-5xl font-bold text-gray-800 mb-6">
+            Favorite Moments
+          </h2>
+          <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+            A few snapshots from over the years
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto">
+          {images.map((img, idx) => (
+            <div key={idx} className="overflow-hidden rounded-lg shadow-md">
+              <img src={img.src} alt={img.alt} className="w-full h-56 object-cover" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ImageGallery;

--- a/src/components/WhyChooseUs.tsx
+++ b/src/components/WhyChooseUs.tsx
@@ -105,6 +105,7 @@ const WhyChooseUs: React.FC = () => {
             PawClean Pro delivers smart, caring service you can count on
           </p>
         </div>
+                    <img src="/images/iowa-state-dogs.jpg" alt="Playing with dogs on the Iowa State University lawn" className="mx-auto rounded-lg shadow-md w-full max-w-md mt-6" />
         
         {/* Stats Counter */}
         <div id="stats-section" className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-16">


### PR DESCRIPTION
## Summary
- add new `ImageGallery` section with five nostalgic images
- show founder playing with dogs in hero
- highlight happy dog on green lawn in how-it-works
- drop Iowa State photo into why-choose-us section
- display Iowa landscape image in final CTA

## Testing
- `npm run build`
- `npm run lint` *(fails: several unused-vars errors already present)*

------
https://chatgpt.com/codex/tasks/task_e_6876d3eea19483238948e45b6c30eb1b